### PR TITLE
Improve API logging and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ pip install -r requirements.txt
 uvicorn main:app --reload
 ```
 
+Logging is configured at **INFO** level on startup so you will see data
+loading and request information in the console.
+
 When running locally the API is available at `http://127.0.0.1:8000`.
 
 ### Running Tests
@@ -34,6 +37,10 @@ pytest
 Unit data is loaded once at startup by `DataLoader` which keeps a dictionary
 for fast lookups. Use `get_unit_by_id` to retrieve a specific unit without
 iterating over the entire list.
+
+If data files cannot be read, the application now returns a 500 JSON response
+with `{"detail": "Internal server error"}` instead of exposing a stack
+trace.
 
 ## Hosted API
 

--- a/app/api.py
+++ b/app/api.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Path
 
 from .loaders import get_data_loader
 
@@ -13,8 +13,13 @@ def list_units():
 
 
 @router.get("/units/{unit_id}")
-def get_unit(unit_id: str):
-    """Return unit details by ID."""
+def get_unit(unit_id: str = Path(..., regex="^[a-zA-Z0-9]+$")):
+    """Return unit details by ID.
+
+    The ``unit_id`` path parameter must be alphanumeric. A request with an
+    invalid identifier will return a ``422`` response before reaching this
+    handler.
+    """
     loader = get_data_loader()
     unit = loader.get_unit_by_id(unit_id)
     if unit:

--- a/app/loaders.py
+++ b/app/loaders.py
@@ -4,7 +4,11 @@ from typing import Any, Dict, List, Optional
 
 
 class DataLoadError(Exception):
-    """Raised when data files fail to load."""
+    """Raised when data files fail to load.
+
+    The API converts this exception into a ``500`` JSON error response so that
+    stack traces are not exposed to clients.
+    """
 
 
 class DataLoader:

--- a/main.py
+++ b/main.py
@@ -1,14 +1,33 @@
-from fastapi import FastAPI
+"""Application entry point for the WCR Data API."""
+
+import logging
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 
 from app.api import router
+from app.loaders import DataLoadError
 
 app = FastAPI(title="WCR Data API")
 app.include_router(router)
 
 
+@app.exception_handler(DataLoadError)
+async def dataloader_error_handler(
+    request: Request, exc: DataLoadError
+) -> JSONResponse:
+    """Return a JSON response when data loading fails."""
+    logging.error("Data loading failed: %s", exc)
+    return JSONResponse(
+        status_code=500,
+        content={"detail": "Internal server error"},
+    )
+
+
 @app.on_event("startup")
 def startup_event():
-    # Load data at startup
+    """Configure logging and load data once on startup."""
+    logging.basicConfig(level=logging.INFO)
     from app.loaders import get_data_loader
 
+    logging.info("Loading unit data")
     get_data_loader()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -34,3 +34,21 @@ def test_categories_structure():
     categories = response.json()
     assert isinstance(categories, dict)
     assert {"factions", "types", "traits", "speeds"} <= set(categories.keys())
+
+
+def test_invalid_unit_id_validation():
+    response = client.get("/units/invalid!")
+    assert response.status_code == 422
+
+
+def test_dataloader_error_returns_500(monkeypatch):
+    from app import api as api_module
+    from app.loaders import DataLoadError
+
+    def fail_loader():
+        raise DataLoadError("boom")
+
+    monkeypatch.setattr(api_module, "get_data_loader", fail_loader)
+    resp = client.get("/units")
+    assert resp.status_code == 500
+    assert resp.json() == {"detail": "Internal server error"}


### PR DESCRIPTION
## Summary
- configure Python logging at startup
- handle `DataLoadError` by returning a 500 JSON response
- validate `unit_id` path parameter for alphanumeric format
- document logging behaviour and error responses
- test new validation and error handling

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a87538520832fa4d0ab9b5df6b392