### PR TITLE
Enable Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Security scan in CI with ``pip-audit``.
 - Additional pre-commit hooks (Ruff, check-yaml, trailing-whitespace,
   end-of-file-fixer).
+- Dependabot configuration for Python and GitHub Actions updates.
 - Example ``.env.example`` file.
 - Project moved to ``src/wcr_api`` package layout.
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ pre-commit run --all-files
 Continuous integration runs the same hooks and additionally checks
 dependencies with `pip-audit`.
 
+### Automatic dependency updates
+
+Dependabot monitors `requirements*.txt` and GitHub Actions workflow files.
+Weekly pull requests keep dependencies secure and up to date. Enable
+Dependabot alerts in the repository settings to receive notifications about
+security issues.
+
 The repository's `.gitignore` excludes environment files, Python bytecode and
 pytest cache directories to avoid committing temporary files.
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ pre-commit
 ruff
 pip-audit
 bandit
+pyyaml

--- a/tests/test_dependabot.py
+++ b/tests/test_dependabot.py
@@ -1,0 +1,12 @@
+import yaml
+from pathlib import Path
+
+
+def test_dependabot_config_valid():
+    cfg_path = Path(".github/dependabot.yml")
+    assert cfg_path.exists(), "dependabot config missing"
+    with cfg_path.open() as f:
+        data = yaml.safe_load(f)
+    assert data["version"] == 2
+    ecosystems = {u["package-ecosystem"] for u in data.get("updates", [])}
+    assert {"pip", "github-actions"} <= ecosystems


### PR DESCRIPTION
## Summary
- configure weekly Dependabot updates for pip and GitHub Actions
- document Dependabot usage
- track setup in changelog
- add unit test for configuration
- include PyYAML in dev requirements

## Testing
- `pre-commit run --files .github/dependabot.yml README.md CHANGELOG.md requirements-dev.txt tests/test_dependabot.py`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685becd71f88832f85715b6e79c82a17