### PR TITLE
Add Snyk scanning to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,12 @@ jobs:
         run: pip-audit -r requirements.txt -r requirements-dev.txt
       - name: Bandit security scan
         run: bandit -r src -q
+      - name: Set up Snyk
+        uses: snyk/actions/setup@v1
+      - name: Snyk test
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: snyk test
       - name: Lint
         run: pre-commit run --show-diff-on-failure --color=always --all-files
       - name: Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Environment-based log level via ``LOG_LEVEL`` variable.
 - Rotating file handler writing logs to ``logs/api.log``.
 - Security scan in CI with ``pip-audit``.
+- Snyk security scanning step in CI workflow.
 - Additional pre-commit hooks (Ruff, check-yaml, trailing-whitespace,
   end-of-file-fixer).
 - Dependabot configuration for Python and GitHub Actions updates.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ pre-commit run --all-files
 ```
 
 Continuous integration runs the same hooks and additionally checks
-dependencies with `pip-audit`.
+dependencies with `pip-audit` and performs a Snyk security scan.
 
 ### Automatic dependency updates
 


### PR DESCRIPTION
## Summary
- integrate Snyk security testing into workflow
- document Snyk scanning in README
- note the new CI step in CHANGELOG

## Testing
- `python -m pre_commit run --all-files --show-diff-on-failure --color=always`
- `PYTHONPATH=.:src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c1c2a7618832fb92e39bf9d44a888