### PR TITLE
Cache pre-commit in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,13 @@ jobs:
         with:
           path: ~/.cache/pip
           key: "${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}"
+      - name: Cache pre-commit
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: "${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}"
+          restore-keys: |
+            ${{ runner.os }}-pre-commit-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file.
 - Railway start command now sets ``PYTHONPATH=src`` before launching ``uvicorn``.
 - Error response for data load failures now returns German message
   ``{"detail": "Interner Serverfehler"}``.
+- CI caches pre-commit hooks for faster runs.
 
 ### Removed
 - Empty `app/__init__.py` module as namespace packages are supported.


### PR DESCRIPTION
## Summary
- speed up pre-commit execution by caching `~/.cache/pre-commit`
- document pre-commit caching in the changelog

## Testing
- `pre-commit run --files .github/workflows/ci.yml CHANGELOG.md`
- `PYTHONPATH=src python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c8ddc6094832fa28bd69e6c34ecd2