### PR TITLE
Add Railway log capture to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,11 @@ jobs:
         with:
           name: coverage
           path: coverage.xml
+      - name: Capture Railway logs
+        run: |
+          mkdir -p logs
+          timeout 30s railway logs --follow > logs/latest_railway.log || true
+      - uses: actions/upload-artifact@v4
+        with:
+          name: railway-logs
+          path: logs/latest_railway.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ All notable changes to this project will be documented in this file.
 - Error response for data load failures now returns German message
   ``{"detail": "Interner Serverfehler"}``.
 - CI caches pre-commit hooks for faster runs.
+- CI streams Railway logs to `logs/latest_railway.log` and uploads the file as
+  an artifact.
 
 ### Removed
 - Empty `app/__init__.py` module as namespace packages are supported.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Continuous integration runs the same hooks and additionally checks
 dependencies with `pip-audit`. The Snyk token must be defined as a
 repository secret. Pull requests from forks don't receive secrets, so the
 Snyk test step is skipped.
+CI also streams Railway logs with `railway logs --follow > logs/latest_railway.log`
+and uploads the file as a build artifact.
 
 ### Security scanning
 


### PR DESCRIPTION
## Summary
- stream Railway logs during CI and upload them
- document the new step in the README
- note the change in the changelog

## Testing
- `pre-commit run --files .github/workflows/ci.yml CHANGELOG.md README.md`
- `python -m pytest --cov=src/wcr_api --cov=main -q --cov-report=xml`

------
https://chatgpt.com/codex/tasks/task_e_685c8ef9832c832fb5adb0fd4f7e9029