### PR TITLE
Add pip-audit pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,9 @@ repos:
       - id: bandit
         args: ["-r", "src"]
         pass_filenames: false
+  - repo: https://github.com/pypa/pip-audit
+    rev: v2.9.0
+    hooks:
+      - id: pip-audit
+        additional_dependencies: ["pip-audit[cyclonedx]", "cyclonedx-bom"]
+        args: ["-r", "requirements.txt", "--format", "columns"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Environment-based log level via ``LOG_LEVEL`` variable.
 - Rotating file handler writing logs to ``logs/api.log``.
 - Security scan in CI with ``pip-audit``.
+- Pre-commit hook for ``pip-audit`` using CycloneDX SBOM support.
 - CI: Use `snyk/actions/setup@v1`; fixed action not found errors.
 - CI: Added SNYK_TOKEN env for Snyk Test; clarified fork tests won't have secrets.
 - CI: Skip Snyk test in forked PRs to prevent missing-secret auth errors.

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ python -m pytest
 
 ### Code style
 
-Use `pre-commit` to automatically run Black, Flake8, Ruff and
-other basic checks:
+Use `pre-commit` to automatically run Black, Flake8, Ruff,
+`pip-audit` and other basic checks:
 
 ```bash
 pre-commit install
@@ -70,10 +70,13 @@ Run all hooks manually with:
 pre-commit run --all-files
 ```
 
-Continuous integration runs the same hooks and additionally checks
-dependencies with `pip-audit`. The Snyk token must be defined as a
-repository secret. Pull requests from forks don't receive secrets, so the
-Snyk test step is skipped.
+The `pip-audit` hook scans `requirements.txt` and outputs a column
+formatted report. It installs `pip-audit[cyclonedx]` and
+`cyclonedx-bom` so CI can also generate a CycloneDX SBOM.
+
+Continuous integration runs the same hooks. The Snyk token must be
+defined as a repository secret. Pull requests from forks don't receive
+secrets, so the Snyk test step is skipped.
 
 ### Security scanning
 


### PR DESCRIPTION
## Summary
- add pip-audit repo with CycloneDX support
- document the new hook in the README
- note pip-audit pre-commit hook in changelog

## Testing
- `pre-commit run --files .pre-commit-config.yaml README.md CHANGELOG.md`
- `PYTHONPATH=src python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c91c4d378832f93b171f3b1b27a66