### PR TITLE
Update dependabot schedule to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
 - CI caches pre-commit hooks for faster runs.
 - CI streams Railway logs to `logs/latest_railway.log` and uploads the file as
   an artifact.
+- Dependabot update schedule changed to daily.
 
 ### Removed
 - Empty `app/__init__.py` module as namespace packages are supported.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ forks won't receive this secret, so the Snyk test step is skipped.
 ### Automatic dependency updates
 
 Dependabot monitors `requirements*.txt` and GitHub Actions workflow files.
-Weekly pull requests keep dependencies secure and up to date. Enable
+Daily pull requests keep dependencies secure and up to date. Enable
 Dependabot alerts in the repository settings to receive notifications about
 security issues.
 

--- a/tests/test_dependabot.py
+++ b/tests/test_dependabot.py
@@ -10,3 +10,5 @@ def test_dependabot_config_valid():
     assert data["version"] == 2
     ecosystems = {u["package-ecosystem"] for u in data.get("updates", [])}
     assert {"pip", "github-actions"} <= ecosystems
+    for update in data.get("updates", []):
+        assert update.get("schedule", {}).get("interval") == "daily"


### PR DESCRIPTION
## Summary
- run Dependabot every day
- test daily schedule
- document daily updates

## Testing
- `pre-commit run --files .github/dependabot.yml CHANGELOG.md README.md tests/test_dependabot.py`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c9210f560832f9e527c506dd58ab9