### PR TITLE
Add CycloneDX SBOM generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,12 @@ jobs:
           pip install -r requirements.txt -r requirements-dev.txt
       - name: Security audit
         run: pip-audit -r requirements.txt -r requirements-dev.txt
+      - name: Generate SBOM
+        run: cyclonedx-bom -r requirements.txt -r requirements-dev.txt -o sbom.xml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: sbom.xml
       - name: Bandit security scan
         run: bandit -r src -q
       - uses: snyk/actions/setup@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Rotating file handler writing logs to ``logs/api.log``.
 - Security scan in CI with ``pip-audit``.
 - Pre-commit hook for ``pip-audit`` using CycloneDX SBOM support.
+- CI: CycloneDX SBOM generation uploaded as `sbom.xml` artifact.
 - CI: Use `snyk/actions/setup@v1`; fixed action not found errors.
 - CI: Added SNYK_TOKEN env for Snyk Test; clarified fork tests won't have secrets.
 - CI: Skip Snyk test in forked PRs to prevent missing-secret auth errors.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ pre-commit run --all-files
 
 The `pip-audit` hook scans `requirements.txt` and outputs a column
 formatted report. It installs `pip-audit[cyclonedx]` and
-`cyclonedx-bom` so CI can also generate a CycloneDX SBOM.
+`cyclonedx-bom` so CI can generate a CycloneDX software bill of
+materials. Continuous integration runs `cyclonedx-bom` after the audit
+step to create `sbom.xml` and uploads the file as a build artifact.
 
 Continuous integration runs the same hooks. The Snyk token must be
 defined as a repository secret. Pull requests from forks don't receive

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ ruff
 pip-audit
 bandit
 pyyaml
+cyclonedx-bom==6.1.1


### PR DESCRIPTION
## Summary
- generate a CycloneDX SBOM in CI after `pip-audit`
- upload the `sbom.xml` artifact
- document SBOM generation in the README
- note SBOM upload in the changelog
- include `cyclonedx-bom` in dev requirements

## Testing
- `pre-commit run --files README.md CHANGELOG.md requirements-dev.txt .github/workflows/ci.yml`
- `PYTHONPATH=src python -m pytest --cov=src/wcr_api --cov=main -q --cov-report=xml`

------
https://chatgpt.com/codex/tasks/task_e_685c94bfd1a4832f8c7575937c45863d