### PR TITLE
Fix CI badge owner link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WCR Data API
 
-[![CI](https://github.com/<owner>/wcr-api/actions/workflows/ci.yml/badge.svg)](https://github.com/<owner>/wcr-api/actions/workflows/ci.yml)
+[![CI](https://github.com/Lotus-Gaming-DE/wcr-api/actions/workflows/ci.yml/badge.svg)](https://github.com/Lotus-Gaming-DE/wcr-api/actions/workflows/ci.yml)
 
 This project provides a simple REST API to serve data from `data/units.json` and
 `data/categories.json`.


### PR DESCRIPTION
## Summary
- correct the CI badge owner in README

## Testing
- `pre-commit run --files README.md`
- `PYTHONPATH=src python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c98fc84e4832f9bce0b1e9223f0c1