### PR TITLE
Add pinned pip-audit version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to this project will be documented in this file.
 - CI streams Railway logs to `logs/latest_railway.log` and uploads the file as
   an artifact.
 - Dependabot update schedule changed to daily.
+- Pinned `pip-audit` to version 2.9.0 for consistent SBOM generation.
 
 ### Removed
 - Empty `app/__init__.py` module as namespace packages are supported.

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ Run all hooks manually with:
 pre-commit run --all-files
 ```
 
-The `pip-audit` hook scans `requirements.txt` and outputs a column
-formatted report. It installs `pip-audit[cyclonedx]` and
-`cyclonedx-bom` so CI can generate a CycloneDX software bill of
+The `pip-audit` hook (version `2.9.0`) scans `requirements.txt` and
+outputs a column formatted report. It installs `pip-audit[cyclonedx]`
+and `cyclonedx-bom` so CI can generate a CycloneDX software bill of
 materials. CI runs the same hooks and then streams Railway logs with
 `railway logs --follow > logs/latest_railway.log` which is uploaded as a
 build artifact.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ pytest-cov
 pytest-timeout
 pre-commit
 ruff
-pip-audit
+pip-audit==2.9.0
 bandit
 pyyaml
 cyclonedx-bom==6.1.1


### PR DESCRIPTION
## Summary
- pin pip-audit to version 2.9.0 for stable SBOM output
- document pip-audit version in README
- note pip-audit version pin in CHANGELOG

## Testing
- `pre-commit run --files README.md CHANGELOG.md requirements-dev.txt`
- `python -m pytest -q`
- `pip-audit -r requirements.txt -r requirements-dev.txt --format columns`

------
https://chatgpt.com/codex/tasks/task_e_685c1b55d9cc832f8cb994d5013dffe6