### PR TITLE
Update Dependabot docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ All notable changes to this project will be documented in this file.
 - CI caches pre-commit hooks for faster runs.
 - CI streams Railway logs to `logs/latest_railway.log` and uploads the file as
   an artifact.
+- CI caches pip downloads alongside pre-commit hooks for faster builds.
+- Documented Dependabot's daily update mechanism and CI caching in README.
 - Dependabot update schedule changed to daily.
 - Pinned `pip-audit` to version 2.9.0 for consistent SBOM generation.
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ the Snyk step is skipped in that scenario.
 
 Dependabot checks `requirements*.txt` and workflow files as configured in
 `.github/dependabot.yml`. It opens daily pull requests that trigger the full CI
-pipeline. Enable Dependabot alerts in repository settings to receive security
+pipeline with linting, tests and `pip-audit`. CI caches pip downloads and
+pre-commit hooks for faster runs and stores build logs under `logs/`.
+Enable Dependabot alerts in repository settings to receive security
 notifications.
 
 The repository's `.gitignore` excludes environment files, Python bytecode,


### PR DESCRIPTION
## Summary
- clarify Dependabot PR behavior
- mention CI caching of pip downloads and pre-commit hooks

## Testing
- `pre-commit run --files README.md CHANGELOG.md`
- `PYTHONPATH=src:. pytest -q`
- `pip-audit -r requirements.txt -r requirements-dev.txt`


------
https://chatgpt.com/codex/tasks/task_e_685c9f5a1ab8832f97c25cf28102f6ed