### PR TITLE
Add async test setup and CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,9 @@ jobs:
       - name: Lint
         run: pre-commit run --show-diff-on-failure --color=always --all-files
       - name: Test
-        run: python -m pytest --cov=src/wcr_api --cov=main -q --cov-report=xml
+        run: |
+          python -m pytest --cov=. --cov-report=term-missing:skip-covered \
+            --cov-report=xml
       - uses: actions/upload-artifact@v4
         with:
           name: coverage

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ __pycache__/
 logs/
 data/
 coverage.xml
+.coverage

--- a/README.md
+++ b/README.md
@@ -47,12 +47,13 @@ PYTHONPATH=src uvicorn main:app --host 0.0.0.0 --port $PORT
 
 ### Running Tests
 
-Install development dependencies and run the test suite with `python -m pytest`.
-Running tests as a module ensures the package imports correctly:
+Install development dependencies and run the test suite with coverage enabled.
+Running tests as a module ensures the package imports correctly and collects
+coverage metrics:
 
 ```bash
 pip install -r requirements-dev.txt
-python -m pytest
+python -m pytest --cov=. --cov-report=term-missing:skip-covered
 ```
 
 ### Code style

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 addopts = --strict-markers --timeout=30
+asyncio_mode = auto
 testpaths = tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ flake8
 pytest
 pytest-cov
 pytest-timeout
+pytest-asyncio
 pre-commit
 ruff
 pip-audit==2.9.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
 sys.path.insert(0, str(ROOT / "src"))
 
 

--- a/tests/test_async_api.py
+++ b/tests/test_async_api.py
@@ -1,0 +1,13 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from main import app
+
+
+@pytest.mark.asyncio
+async def test_list_units_async():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/units")
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)


### PR DESCRIPTION
## Summary
- add root path to `sys.path` for tests
- support asyncio tests using `pytest-asyncio`
- include async API test
- show coverage in CI and README
- ignore `.coverage` files

## Testing
- `pre-commit run --files tests/conftest.py tests/test_async_api.py README.md requirements-dev.txt pytest.ini .github/workflows/ci.yml`
- `pytest --cov=. --cov-report=term-missing:skip-covered -q`

------
https://chatgpt.com/codex/tasks/task_e_685ca62929e8832f91b51972998940a2