### PR TITLE
Improve German localization for 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ list.
 
 If data files cannot be read, the application now returns a 500 JSON response
 with `{"detail": "Interner Serverfehler"}` instead of exposing a stack
-trace.
+trace. Requests for unknown unit IDs return a 404 response containing
+`{"detail": "Einheit nicht gefunden"}`.
 
 ### Data files
 

--- a/src/wcr_api/api.py
+++ b/src/wcr_api/api.py
@@ -54,7 +54,7 @@ def get_unit(unit_id: str = Path(..., pattern="^[a-zA-Z0-9-]+$")) -> dict:
     unit = loader.get_unit_by_id(unit_id)
     if unit:
         return unit
-    raise HTTPException(status_code=404, detail="Unit not found")
+    raise HTTPException(status_code=404, detail="Einheit nicht gefunden")
 
 
 @router.get("/categories")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,6 +29,7 @@ def test_get_unit_by_id_or_404():
 
     resp_404 = client.get("/units/nonexistent")
     assert resp_404.status_code == 404
+    assert resp_404.json() == {"detail": "Einheit nicht gefunden"}
 
 
 def test_get_unit_with_hyphenated_id():


### PR DESCRIPTION
## Summary
- localise 404 error message in API
- document new 404 response in README
- test 404 response body

## Testing
- `pre-commit run --files src/wcr_api/api.py README.md tests/test_api.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ca8b2482c832fbd8adca535aeb9b4