### PR TITLE
Add manual Railway logs workflow

### DIFF
--- a/.github/workflows/railway_logs.yml
+++ b/.github/workflows/railway_logs.yml
@@ -1,0 +1,30 @@
+name: Railway Logs
+
+on:
+  workflow_dispatch:
+
+jobs:
+  fetch-logs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install Railway CLI
+        run: npm install -g railway
+      - name: Login to Railway
+        run: railway login --token "$RAILWAY_TOKEN"
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+      - name: Stream production logs
+        run: |
+          mkdir -p logs
+          railway logs --environment production --service bot --detach > logs/latest_railway.log || true
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: railway-latest-log
+          path: logs/latest_railway.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
   `SNYK_TOKEN`.
 - Example ``.env.example`` file.
 - Project moved to ``src/wcr_api`` package layout.
+- Manual workflow to fetch production Railway logs on demand.
 
 ### Changed
 - Unit ID path parameter now accepts hyphenated IDs.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ and `cyclonedx-bom` so CI can generate a CycloneDX software bill of
 materials. CI runs the same hooks and then streams Railway logs with
 `railway logs --follow > logs/latest_railway.log` which is uploaded as a
 build artifact.
+If more logs are needed, trigger the `Railway Logs` workflow from the Actions
+tab to capture production logs for the `bot` service.
 
 ### Security scanning
 


### PR DESCRIPTION
## Summary
- enable manual Railway log retrieval via new workflow
- document how to run the workflow in the README
- update changelog

## Testing
- `pre-commit run --files .github/workflows/railway_logs.yml CHANGELOG.md README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d1e754040832f88cd5f23ba255217